### PR TITLE
feat: sound types, throwable structure refactoring

### DIFF
--- a/overlay/src/utils/async.ts
+++ b/overlay/src/utils/async.ts
@@ -1,6 +1,7 @@
-import { Item, Sound } from "$shared/dataV2";
+import { Item } from "$shared/dataV2";
 
 import getBackendURL from "./url";
+import { PartialSoundModel } from "../vtftk/types";
 
 export async function sleep(duration: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, duration));
@@ -56,7 +57,7 @@ export async function loadAudio(src: string): Promise<HTMLAudioElement> {
 export type LoadedItemMap = Map<string, HTMLImageElement>;
 export type LoadedSoundMap = Map<string, LoadedSoundData>;
 export type LoadedSoundData = {
-  config: Sound;
+  config: PartialSoundModel;
   sound: HTMLAudioElement;
 };
 
@@ -64,7 +65,7 @@ export async function loadItems(items: Item[]): Promise<LoadedItemMap> {
   const results = await Promise.allSettled(
     items.map(async (item) => ({
       id: item.id,
-      image: await loadImage(item.image.src),
+      image: await loadImage(item.config.image.src),
     })),
   );
 
@@ -81,7 +82,9 @@ export async function loadItems(items: Item[]): Promise<LoadedItemMap> {
   return output;
 }
 
-export async function loadSounds(sounds: Sound[]): Promise<LoadedSoundMap> {
+export async function loadSounds(
+  sounds: PartialSoundModel[],
+): Promise<LoadedSoundMap> {
   const results = await Promise.allSettled(
     sounds.map(async (config) => ({
       sound: await loadAudio(config.src),

--- a/overlay/src/vtftk/events.ts
+++ b/overlay/src/vtftk/events.ts
@@ -293,21 +293,22 @@ async function onThrowItemEvent(
 }
 
 function pickRandomSound(
-  item: ItemWithSoundIds,
+  soundIds: string[],
   sounds: LoadedSoundMap,
   clone: boolean = false,
 ) {
-  if (item.impact_sound_ids.length > 0) {
-    const randomSoundId = arrayRandom(item.impact_sound_ids);
-    const audio = sounds.get(randomSoundId);
-    if (audio) {
-      return {
-        config: audio.config,
-        sound: clone
-          ? (audio.sound.cloneNode() as HTMLAudioElement)
-          : audio.sound,
-      };
-    }
+  if (soundIds.length < 1) return null;
+
+  const randomSoundId = arrayRandom(soundIds);
+  const audio = sounds.get(randomSoundId);
+
+  if (audio) {
+    return {
+      config: audio.config,
+      sound: clone
+        ? (audio.sound.cloneNode() as HTMLAudioElement)
+        : audio.sound,
+    };
   }
 
   return null;
@@ -350,7 +351,15 @@ function throwRandomItem(
   // No item found
   if (item === null) return Promise.resolve();
 
-  const impactAudio = pickRandomSound(item.config, loadedSounds);
+  const impactAudio = pickRandomSound(
+    item.config.impact_sound_ids,
+    loadedSounds,
+  );
+
+  const windupAudio = pickRandomSound(
+    item.config.windup_sound_ids,
+    loadedSounds,
+  );
 
   return throwItem(
     socket,
@@ -361,6 +370,7 @@ function throwRandomItem(
     item.config,
     item.image,
     impactAudio,
+    windupAudio,
   );
 }
 

--- a/overlay/src/vtftk/types.ts
+++ b/overlay/src/vtftk/types.ts
@@ -1,4 +1,4 @@
-import { Item, Sound, SoundId } from "$shared/dataV2";
+import { Item, SoundId } from "$shared/dataV2";
 
 export * from "$shared/dataV2";
 export * from "$shared/appData";
@@ -8,6 +8,15 @@ export const enum ThrowItemConfigType {
   Barrage = "Barrage",
   All = "All",
 }
+
+/**
+ * Sound with UI specific fields stripped
+ */
+export type PartialSoundModel = {
+  id: SoundId;
+  src: string;
+  volume: number;
+};
 
 export type ThrowItemConfig =
   | { type: ThrowItemConfigType.All; amount: number }
@@ -20,9 +29,10 @@ export type ThrowItemConfig =
 
 export type ItemWithSoundIds = Item & {
   impact_sound_ids: SoundId[];
+  windup_sound_ids: SoundId[];
 };
 
 export type ItemWithSounds = {
   items: ItemWithSoundIds[];
-  sounds: Sound[];
+  sounds: PartialSoundModel[];
 };

--- a/overlay/src/vtube-studio/throw-item.ts
+++ b/overlay/src/vtube-studio/throw-item.ts
@@ -116,6 +116,21 @@ export async function throwItem(
 
   const { image: imageConfig, windup } = config.config;
 
+  if (windup.enabled) {
+    // Play the windup sound
+    if (windupAudio !== null) {
+      try {
+        windupAudio.sound.volume =
+          appData.sounds_config.global_volume * windupAudio.config.volume;
+        windupAudio.sound.play();
+      } catch (err) {
+        console.error("failed to play windup audio", err);
+      }
+    }
+
+    await sleep(windup.duration);
+  }
+
   const scaledImageWidth = image.width * imageConfig.scale * itemScale;
   const scaledImageHeight = image.height * imageConfig.scale * itemScale;
 
@@ -149,21 +164,6 @@ export async function throwItem(
   pivot.appendChild(movement);
   root.appendChild(pivot);
   document.body.appendChild(root);
-
-  if (windup.enabled) {
-    // Play the windup sound
-    if (windupAudio !== null) {
-      try {
-        windupAudio.sound.volume =
-          appData.sounds_config.global_volume * windupAudio.config.volume;
-        windupAudio.sound.play();
-      } catch (err) {
-        console.error("failed to play windup audio", err);
-      }
-    }
-
-    await sleep(windup.duration);
-  }
 
   // Impact is encountered half way through the animation
   const impactTimeout = throwables.duration / 2 + throwables.impact_delay;

--- a/overlay/src/vtube-studio/throw-item.ts
+++ b/overlay/src/vtube-studio/throw-item.ts
@@ -15,9 +15,9 @@ import {
   AppData,
   ModelId,
   ThrowDirection,
+  ItemImageConfig,
   ModelCalibration,
   ItemWithSoundIds,
-  ThrowableImageConfig,
 } from "../vtftk/types";
 
 const HORIZONTAL_PHYSICS_SCALE = 3;
@@ -41,7 +41,7 @@ export function setPhysicsEngineConfig(config: PhysicsEngineConfig) {
  * @returns The loaded resources
  */
 export async function loadThrowableResources(
-  imageConfig: ThrowableImageConfig,
+  imageConfig: ItemImageConfig,
   soundConfig: Sound | null,
 ): Promise<{ image: HTMLImageElement | null; audio: HTMLAudioElement | null }> {
   // Load the image and audio if present
@@ -69,6 +69,7 @@ export async function loadThrowableResources(
  * @param config Configuration for the thrown item
  * @param image Image element to use for the thrown item
  * @param impactAudio Audio element to play when the item impacts the target
+ * @param windupAudio Audio element to play when the item is winding up
  * @returns Promise that completes after the item has been completely thrown and removed
  */
 export async function throwItem(
@@ -79,6 +80,7 @@ export async function throwItem(
   config: ItemWithSoundIds,
   image: HTMLImageElement,
   impactAudio: LoadedSoundData | null,
+  windupAudio: LoadedSoundData | null,
 ) {
   const { modelID, modelPosition } = await requestCurrentModel(socket);
 
@@ -112,11 +114,13 @@ export async function throwItem(
     throwables.item_scale.max,
   );
 
-  const scaledImageWidth = image.width * config.image.scale * itemScale;
-  const scaledImageHeight = image.height * config.image.scale * itemScale;
+  const { image: imageConfig, windup } = config.config;
+
+  const scaledImageWidth = image.width * imageConfig.scale * itemScale;
+  const scaledImageHeight = image.height * imageConfig.scale * itemScale;
 
   const thrown = createThrownImage(
-    config.image,
+    imageConfig,
     image,
     scaledImageWidth,
     scaledImageHeight,
@@ -145,6 +149,21 @@ export async function throwItem(
   pivot.appendChild(movement);
   root.appendChild(pivot);
   document.body.appendChild(root);
+
+  if (windup.enabled) {
+    // Play the windup sound
+    if (windupAudio !== null) {
+      try {
+        windupAudio.sound.volume =
+          appData.sounds_config.global_volume * windupAudio.config.volume;
+        windupAudio.sound.play();
+      } catch (err) {
+        console.error("failed to play windup audio", err);
+      }
+    }
+
+    await sleep(windup.duration);
+  }
 
   // Impact is encountered half way through the animation
   const impactTimeout = throwables.duration / 2 + throwables.impact_delay;
@@ -273,11 +292,13 @@ function handleThrowableImpact(
     }
   }
 
+  const { image } = config.config;
+
   // Make the VTuber model flinch from the impact
   flinch(socket, modelParameters, {
     angle,
     eyeState: appData.model_config.eyes_on_hit,
-    magnitude: config.image.weight,
+    magnitude: image.weight,
     leftSide,
     returnSpeed: 0.3,
   });
@@ -314,7 +335,7 @@ function createRootContainer(modelPosition: ModelPosition) {
  * @returns The image element
  */
 function createThrownImage(
-  config: ThrowableImageConfig,
+  config: ItemImageConfig,
   image: HTMLImageElement,
 
   scaledWidth: number,

--- a/src-tauri/src/database/entity/items_sounds.rs
+++ b/src-tauri/src/database/entity/items_sounds.rs
@@ -2,12 +2,13 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
 // Type alias helpers for the database entity types
-pub type ItemImpactSoundsEntity = Entity;
-pub type ItemImpactSoundsActiveModel = ActiveModel;
-pub type ItemImpactSoundsColumn = Column;
+pub type ItemsSoundsEntity = Entity;
+pub type ItemsSoundsModel = Model;
+pub type ItemsSoundsActiveModel = ActiveModel;
+pub type ItemsSoundsColumn = Column;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
-#[sea_orm(table_name = "items_impact_sounds")]
+#[sea_orm(table_name = "items_sounds")]
 pub struct Model {
     /// ID of the item
     #[sea_orm(primary_key)]
@@ -15,6 +16,18 @@ pub struct Model {
     /// ID of the sound
     #[sea_orm(primary_key)]
     pub sound_id: Uuid,
+    /// Type of sound
+    #[sea_orm(primary_key)]
+    pub sound_type: SoundType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::None)")]
+pub enum SoundType {
+    #[sea_orm(string_value = "Impact")]
+    Impact,
+    #[sea_orm(string_value = "Windup")]
+    Windup,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/src-tauri/src/database/entity/links.rs
+++ b/src-tauri/src/database/entity/links.rs
@@ -1,19 +1,19 @@
 use sea_orm::{Linked, RelationTrait};
 
-use crate::database::entity::items_impact_sounds;
+use crate::database::entity::items_sounds;
 
 /// Relationship linking item to its impact sounds using the
 /// junction table
-pub struct ItemImpactSounds;
+pub struct ItemSounds;
 
-impl Linked for ItemImpactSounds {
+impl Linked for ItemSounds {
     type FromEntity = super::items::Entity;
     type ToEntity = super::sounds::Entity;
 
     fn link(&self) -> Vec<sea_orm::LinkDef> {
         vec![
-            items_impact_sounds::Relation::Item.def().rev(),
-            items_impact_sounds::Relation::Sound.def(),
+            items_sounds::Relation::Item.def().rev(),
+            items_sounds::Relation::Sound.def(),
         ]
     }
 }

--- a/src-tauri/src/database/entity/mod.rs
+++ b/src-tauri/src/database/entity/mod.rs
@@ -7,7 +7,7 @@ pub mod event_executions;
 pub mod event_logs;
 pub mod events;
 pub mod items;
-pub mod items_impact_sounds;
+pub mod items_sounds;
 pub mod key_value;
 pub mod links;
 pub mod model_data;

--- a/src-tauri/src/database/migration/m20241208_060123_create_items_table.rs
+++ b/src-tauri/src/database/migration/m20241208_060123_create_items_table.rs
@@ -18,7 +18,7 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .col(pk_uuid(Items::Id))
                     .col(string(Items::Name))
-                    .col(json(Items::Image))
+                    .col(json(Items::Config))
                     .col(integer(Items::Order))
                     .col(date_time(Items::CreatedAt))
                     .to_owned(),
@@ -38,7 +38,7 @@ pub enum Items {
     Table,
     Id,
     Name,
-    Image,
+    Config,
     Order,
     CreatedAt,
 }

--- a/src-tauri/src/database/migration/m20241208_063859_create_items_sounds_junction_table.rs
+++ b/src-tauri/src/database/migration/m20241208_063859_create_items_sounds_junction_table.rs
@@ -3,7 +3,7 @@
 //! Migration that creates the "items_impact_sounds" junction table which stores
 //! the connection between items and any number of sounds
 
-use sea_orm_migration::{prelude::*, schema::uuid};
+use sea_orm_migration::{prelude::*, schema::*};
 
 use super::{
     m20241208_060123_create_items_table::Items, m20241208_060144_create_sounds_table::Sounds,
@@ -18,22 +18,24 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(ItemsImpactSounds::Table)
+                    .table(ItemsSounds::Table)
                     .if_not_exists()
-                    .col(uuid(ItemsImpactSounds::ItemId))
-                    .col(uuid(ItemsImpactSounds::SoundId))
-                    // Junction table uses a composite key of the item and sound ids combined
+                    .col(uuid(ItemsSounds::ItemId))
+                    .col(uuid(ItemsSounds::SoundId))
+                    .col(string(ItemsSounds::SoundType))
+                    // Junction table uses a composite key of the item, sound id and sound type combined
                     .primary_key(
                         Index::create()
-                            .name("pk_items_impact_sounds")
-                            .col(ItemsImpactSounds::ItemId)
-                            .col(ItemsImpactSounds::SoundId),
+                            .name("pk_items_sounds")
+                            .col(ItemsSounds::ItemId)
+                            .col(ItemsSounds::SoundId)
+                            .col(ItemsSounds::SoundType),
                     )
                     // Connect to items table
                     .foreign_key(
                         ForeignKey::create()
-                            .name("fk_items_impact_sounds_item_id")
-                            .from(ItemsImpactSounds::Table, ItemsImpactSounds::ItemId)
+                            .name("fk_items_sounds_item_id")
+                            .from(ItemsSounds::Table, ItemsSounds::ItemId)
                             .to(Items::Table, Items::Id)
                             .on_delete(ForeignKeyAction::Cascade)
                             .on_update(ForeignKeyAction::Cascade),
@@ -41,8 +43,8 @@ impl MigrationTrait for Migration {
                     // Connect to sounds table
                     .foreign_key(
                         ForeignKey::create()
-                            .name("fk_items_impact_sounds_sound_id")
-                            .from(ItemsImpactSounds::Table, ItemsImpactSounds::SoundId)
+                            .name("fk_items_sounds_sound_id")
+                            .from(ItemsSounds::Table, ItemsSounds::SoundId)
                             .to(Sounds::Table, Sounds::Id)
                             .on_delete(ForeignKeyAction::Cascade)
                             .on_update(ForeignKeyAction::Cascade),
@@ -54,7 +56,7 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(ItemsImpactSounds::Table).to_owned())
+            .drop_table(Table::drop().table(ItemsSounds::Table).to_owned())
             .await?;
 
         Ok(())
@@ -62,8 +64,9 @@ impl MigrationTrait for Migration {
 }
 
 #[derive(DeriveIden)]
-enum ItemsImpactSounds {
+enum ItemsSounds {
     Table,
     ItemId,
     SoundId,
+    SoundType,
 }

--- a/src-tauri/src/database/migration/m20241211_102725_seed_defaults.rs
+++ b/src-tauri/src/database/migration/m20241211_102725_seed_defaults.rs
@@ -3,7 +3,7 @@ use sea_orm_migration::prelude::*;
 use uuid::Uuid;
 
 use crate::database::entity::{
-    items::{CreateItem, ItemModel, ThrowableImageConfig},
+    items::{CreateItem, ItemConfig, ItemImageConfig, ItemModel},
     sounds::{CreateSound, SoundModel},
 };
 
@@ -40,13 +40,17 @@ impl MigrationTrait for Migration {
                 &db,
                 CreateItem {
                     name: name.to_string(),
-                    image: ThrowableImageConfig {
-                        src: format!("backend://defaults/throwable_images/{file_name}"),
-                        pixelate: *pixelate,
-                        scale: *scale,
-                        weight: 1.0,
+                    config: ItemConfig {
+                        image: ItemImageConfig {
+                            src: format!("backend://defaults/throwable_images/{file_name}"),
+                            pixelate: *pixelate,
+                            scale: *scale,
+                            weight: 1.0,
+                        },
+                        windup: Default::default(),
                     },
                     impact_sounds: impact_sounds.clone(),
+                    windup_sounds: Vec::new(),
                 },
             )
             .await

--- a/src-tauri/src/database/migration/mod.rs
+++ b/src-tauri/src/database/migration/mod.rs
@@ -5,7 +5,7 @@ mod m20241208_060138_create_events_table;
 mod m20241208_060144_create_sounds_table;
 mod m20241208_060200_create_commands_table;
 mod m20241208_060230_create_model_data_table;
-mod m20241208_063859_create_items_impact_sounds_junction_table;
+mod m20241208_063859_create_items_sounds_junction_table;
 mod m20241210_082256_create_event_executions_table;
 mod m20241210_082316_create_command_executions_table;
 mod m20241211_102725_seed_defaults;
@@ -28,7 +28,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20241208_060144_create_sounds_table::Migration),
             Box::new(m20241208_060200_create_commands_table::Migration),
             Box::new(m20241208_060230_create_model_data_table::Migration),
-            Box::new(m20241208_063859_create_items_impact_sounds_junction_table::Migration),
+            Box::new(m20241208_063859_create_items_sounds_junction_table::Migration),
             Box::new(m20241210_082256_create_event_executions_table::Migration),
             Box::new(m20241210_082316_create_command_executions_table::Migration),
             Box::new(m20241211_102725_seed_defaults::Migration),

--- a/src-tauri/src/events/mod.rs
+++ b/src-tauri/src/events/mod.rs
@@ -8,7 +8,11 @@ use tokio::sync::broadcast;
 use uuid::Uuid;
 
 use crate::{
-    database::entity::{app_data::AppData, items::ItemModel, sounds::SoundModel},
+    database::entity::{
+        app_data::AppData,
+        items::ItemModel,
+        sounds::{PartialSoundModel, SoundModel},
+    },
     http::models::calibration::CalibrationStep,
 };
 
@@ -19,7 +23,7 @@ pub struct ItemsWithSounds {
     /// All the referenced items
     pub items: Vec<ItemWithSoundIds>,
     /// All the referenced sounds
-    pub sounds: Vec<SoundModel>,
+    pub sounds: Vec<PartialSoundModel>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -27,6 +31,7 @@ pub struct ItemWithSoundIds {
     #[serde(flatten)]
     pub item: ItemModel,
     pub impact_sound_ids: Vec<Uuid>,
+    pub windup_sound_ids: Vec<Uuid>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,7 +69,6 @@ pub fn run() {
             // Item manipulation commands
             commands::items::get_item_by_id,
             commands::items::get_items,
-            commands::items::get_item_sounds,
             commands::items::create_item,
             commands::items::update_item,
             commands::items::update_item_orderings,

--- a/src/lib/api/itemModel.ts
+++ b/src/lib/api/itemModel.ts
@@ -44,10 +44,6 @@ export async function bulkCreateItem(creates: CreateItem[]) {
   invalidateItemsList();
 }
 
-export function getItemSounds(itemId: ItemId) {
-  return invoke<Sound[]>("get_item_sounds", { itemId });
-}
-
 export function getItemById(itemId: ItemId) {
   return invoke<ItemWithImpactSounds | null>("get_item_by_id", { itemId });
 }

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -7,7 +7,10 @@ import type { Item, ItemId, SoundId, ItemConfig } from "$shared/dataV2";
 
 type Option<T> = T | null;
 
-export type ItemWithImpactSounds = Item & { impact_sounds: SoundId[] };
+export type ItemWithImpactSounds = Item & {
+  impact_sounds: SoundId[];
+  windup_sounds: SoundId[];
+};
 
 // File types for file uploads
 export enum StorageFolder {

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -3,17 +3,11 @@ export * from "$shared/appData";
 export * from "$shared/runtimeAppData";
 
 import type { Uuid, MinMax } from "$shared/appData";
-import type {
-  Item,
-  Sound,
-  ItemId,
-  SoundId,
-  ThrowableImageConfig,
-} from "$shared/dataV2";
+import type { Item, ItemId, SoundId, ItemConfig } from "$shared/dataV2";
 
 type Option<T> = T | null;
 
-export type ItemWithImpactSounds = Item & { impact_sounds: Sound[] };
+export type ItemWithImpactSounds = Item & { impact_sounds: SoundId[] };
 
 // File types for file uploads
 export enum StorageFolder {
@@ -446,16 +440,18 @@ export type UpdateSound = {
 
 export type CreateItem = {
   name: string;
-  image: ThrowableImageConfig;
+  config: ItemConfig;
   impact_sounds: SoundId[];
+  windup_sounds: SoundId[];
 };
 
 export type UpdateItem = {
   itemId: ItemId;
   update: Partial<{
     name: string;
-    image: ThrowableImageConfig;
+    config: ItemConfig;
     impact_sounds: SoundId[];
+    windup_sounds: SoundId[];
     order: number;
   }>;
 };

--- a/src/lib/components/HTabs.svelte
+++ b/src/lib/components/HTabs.svelte
@@ -86,7 +86,7 @@
   .tabs-list {
     display: flex;
     flex-flow: row;
-    justify-content: stretch;
+    justify-content: flex-start;
   }
 
   .content {

--- a/src/lib/components/sounds/SelectedSounds.svelte
+++ b/src/lib/components/sounds/SelectedSounds.svelte
@@ -28,7 +28,7 @@
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     overflow: hidden;
-    gap: 0.5rem;
+    gap: 1rem;
   }
 
   .item {

--- a/src/lib/components/throwable/BulkThrowableImport.svelte
+++ b/src/lib/components/throwable/BulkThrowableImport.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { CreateItem, ThrowableImageConfig } from "$lib/api/types";
+  import type { CreateItem, ItemImageConfig } from "$lib/api/types";
 
   import { toast } from "svelte-sonner";
   import { uploadFile } from "$lib/api/data";
@@ -20,9 +20,12 @@
     const images = Array.from(files);
 
     const createItems = await Promise.all(
-      images.map(async (image) => {
-        const imageURL = await uploadFile(StorageFolder.ThrowableImage, image);
-        const imageConfig: ThrowableImageConfig = {
+      images.map(async (imageFile) => {
+        const imageURL = await uploadFile(
+          StorageFolder.ThrowableImage,
+          imageFile,
+        );
+        const image: ItemImageConfig = {
           src: imageURL,
           pixelate: false,
           scale: 1,
@@ -30,9 +33,16 @@
         };
 
         const createItem: CreateItem = {
-          image: imageConfig,
-          name: image.name,
+          config: {
+            image,
+            windup: {
+              enabled: false,
+              duration: 0,
+            },
+          },
+          name: imageFile.name,
           impact_sounds: [],
+          windup_sounds: [],
         };
 
         return createItem;

--- a/src/lib/components/throwable/ThrowablePicker.svelte
+++ b/src/lib/components/throwable/ThrowablePicker.svelte
@@ -90,7 +90,7 @@
               <div class="throwable__image-wrapper">
                 <img
                   class="throwable__image"
-                  src={getBackendURL(item.image.src)}
+                  src={getBackendURL(item.config.image.src)}
                   alt="Throwable"
                 />
               </div>
@@ -119,7 +119,7 @@
             <div class="grid-item__image throwable__image-wrapper">
               <img
                 class="throwable__image"
-                src={getBackendURL(option.image.src)}
+                src={getBackendURL(option.config.image.src)}
                 alt="Throwable"
               />
             </div>

--- a/src/lib/schemas/item.ts
+++ b/src/lib/schemas/item.ts
@@ -17,13 +17,28 @@ export const throwableImageSchema = z.union(
 
 export type ThrowableImageSchema = z.infer<typeof throwableImageSchema>;
 
-export const itemSchema = z.object({
-  name: z.string().min(1, "You must specify a name"),
+export const itemImageConfigSchema = z.object({
   image: throwableImageSchema,
   scale: z.number(),
   weight: z.number(),
   pixelate: z.boolean(),
+});
+
+export const itemWindupConfigSchema = z.object({
+  enabled: z.boolean(),
+  duration: z.number(),
+});
+
+export const itemConfigSchema = z.object({
+  image: itemImageConfigSchema,
+  windup: itemWindupConfigSchema,
+});
+
+export const itemSchema = z.object({
+  name: z.string().min(1, "You must specify a name"),
+  config: itemConfigSchema,
   impactSoundIds: z.array(z.string()),
+  windupSoundIds: z.array(z.string()),
 });
 
 export type ItemSchema = z.infer<typeof itemSchema>;

--- a/src/lib/sections/throwables/ThrowableForm.svelte
+++ b/src/lib/sections/throwables/ThrowableForm.svelte
@@ -32,14 +32,14 @@
   import SolarHeadphonesRoundBoldDuotone from "~icons/solar/headphones-round-bold-duotone";
   import {
     StorageFolder,
+    type ItemConfig,
+    type ItemImageConfig,
     type ItemWithImpactSounds,
-    type ThrowableImageConfig,
   } from "$lib/api/types";
 
   type Props = {
     existing?: ItemWithImpactSounds;
   };
-
   const { existing }: Props = $props();
 
   const appContext = getAppContext();
@@ -64,13 +64,14 @@
   function createFromExisting(
     config: ItemWithImpactSounds,
   ): Partial<ItemSchema> {
+    const { image, windup } = config.config;
     return {
       name: config.name,
-      image: config.image.src,
-      scale: config.image.scale,
-      weight: config.image.weight,
-      pixelate: config.image.pixelate,
-      impactSoundIds: config.impact_sounds.map((sound) => sound.id),
+      image: image.src,
+      scale: image.scale,
+      weight: image.weight,
+      pixelate: image.pixelate,
+      impactSoundIds: config.impact_sounds,
     };
   }
 
@@ -128,11 +129,18 @@
 
   async function save(values: ItemSchema) {
     const imageURL: string = await saveImage(values.image);
-    const imageConfig: ThrowableImageConfig = {
+    const image: ItemImageConfig = {
       src: imageURL,
       pixelate: values.pixelate,
       scale: values.scale,
       weight: values.weight,
+    };
+    const config: ItemConfig = {
+      image,
+      windup: {
+        enabled: false,
+        duration: 0,
+      },
     };
 
     if (existing) {
@@ -140,15 +148,17 @@
         itemId: existing.id,
         update: {
           name: values.name,
-          image: imageConfig,
+          config,
           impact_sounds: values.impactSoundIds,
+          windup_sounds: [],
         },
       });
     } else {
       await createItem({
         name: values.name,
-        image: imageConfig,
+        config,
         impact_sounds: values.impactSoundIds,
+        windup_sounds: [],
       });
     }
   }
@@ -210,7 +220,7 @@
         <ImageUpload
           id="image"
           name="image"
-          value={$data.image ?? existing?.image?.src}
+          value={$data.image ?? existing?.config.image?.src}
           scale={$data.scale * 0.5}
           pixelated={$data.pixelate}
         />

--- a/src/lib/sections/throwables/ThrowableForm.svelte
+++ b/src/lib/sections/throwables/ThrowableForm.svelte
@@ -22,6 +22,7 @@
   import SoundPicker from "$lib/components/sounds/SoundPicker.svelte";
   import SolarAltArrowLeftBold from "~icons/solar/alt-arrow-left-bold";
   import FormTextInput from "$lib/components/form/FormTextInput.svelte";
+  import EnabledSwitch from "$lib/components/input/EnabledSwitch.svelte";
   import FormErrorLabel from "$lib/components/form/FormErrorLabel.svelte";
   import PopoverButton from "$lib/components/popover/PopoverButton.svelte";
   import FormNumberInput from "$lib/components/form/FormNumberInput.svelte";
@@ -30,10 +31,10 @@
   import FormBoundCheckbox from "$lib/components/form/FormBoundCheckbox.svelte";
   import SolarGalleryRoundBoldDuotone from "~icons/solar/gallery-round-bold-duotone";
   import SolarHeadphonesRoundBoldDuotone from "~icons/solar/headphones-round-bold-duotone";
+  import SolarMultipleForwardRightBoldDuotone from "~icons/solar/multiple-forward-right-bold-duotone";
   import {
     StorageFolder,
     type ItemConfig,
-    type ItemImageConfig,
     type ItemWithImpactSounds,
   } from "$lib/api/types";
 
@@ -54,11 +55,20 @@
   // Defaults when creating a new throwable
   const createDefaults: Partial<ItemSchema> = {
     name: "",
-    image: undefined,
-    scale: 1,
-    weight: 1,
-    pixelate: false,
+    config: {
+      image: {
+        image: undefined!,
+        scale: 1,
+        weight: 1,
+        pixelate: false,
+      },
+      windup: {
+        enabled: false,
+        duration: 1000,
+      },
+    },
     impactSoundIds: [],
+    windupSoundIds: [],
   };
 
   function createFromExisting(
@@ -67,11 +77,20 @@
     const { image, windup } = config.config;
     return {
       name: config.name,
-      image: image.src,
-      scale: image.scale,
-      weight: image.weight,
-      pixelate: image.pixelate,
+      config: {
+        image: {
+          image: image.src,
+          scale: image.scale,
+          weight: image.weight,
+          pixelate: image.pixelate,
+        },
+        windup: {
+          enabled: windup.enabled,
+          duration: windup.duration,
+        },
+      },
       impactSoundIds: config.impact_sounds,
+      windupSoundIds: config.windup_sounds,
     };
   }
 
@@ -128,18 +147,19 @@
   }
 
   async function save(values: ItemSchema) {
-    const imageURL: string = await saveImage(values.image);
-    const image: ItemImageConfig = {
-      src: imageURL,
-      pixelate: values.pixelate,
-      scale: values.scale,
-      weight: values.weight,
-    };
+    const { image, windup } = values.config;
+    const imageURL: string = await saveImage(image.image);
+
     const config: ItemConfig = {
-      image,
+      image: {
+        src: imageURL,
+        pixelate: image.pixelate,
+        scale: image.scale,
+        weight: image.weight,
+      },
       windup: {
-        enabled: false,
-        duration: 0,
+        enabled: windup.enabled,
+        duration: windup.duration,
       },
     };
 
@@ -150,7 +170,7 @@
           name: values.name,
           config,
           impact_sounds: values.impactSoundIds,
-          windup_sounds: [],
+          windup_sounds: values.windupSoundIds,
         },
       });
     } else {
@@ -158,7 +178,7 @@
         name: values.name,
         config,
         impact_sounds: values.impactSoundIds,
-        windup_sounds: [],
+        windup_sounds: values.windupSoundIds,
       });
     }
   }
@@ -200,13 +220,13 @@
     />
 
     <FormSlider
-      id="weight"
-      name="weight"
+      id="config.image.weight"
+      name="config.image.weight"
       label="Weight"
       min={0}
       max={4}
       step={0.1}
-      value={$data.weight}
+      value={$data.config.image.weight}
       description="Weight affects how much force your model is hit with when the item impacts (Default: 1)"
       showTicks
     />
@@ -218,19 +238,19 @@
     <div class="row-group">
       <div class="column">
         <ImageUpload
-          id="image"
-          name="image"
-          value={$data.image ?? existing?.config.image?.src}
-          scale={$data.scale * 0.5}
-          pixelated={$data.pixelate}
+          id="config.image.image"
+          name="config.image.image"
+          value={$data.config.image.image ?? existing?.config.image?.src}
+          scale={$data.config.image.scale * 0.5}
+          pixelated={$data.config.image.pixelate}
         />
-        <FormErrorLabel name="image" />
+        <FormErrorLabel name="config.image.image" />
       </div>
 
       <div class="column" style="flex: auto;">
         <FormNumberInput
-          id="scale"
-          name="scale"
+          id="config.image.scale"
+          name="config.image.scale"
           label="Scale"
           min={0.1}
           max={10}
@@ -238,8 +258,8 @@
         />
 
         <FormBoundCheckbox
-          id="pixelate"
-          name="pixelate"
+          id="config.image.pixelate"
+          name="config.image.pixelate"
           label="Pixelate"
           description="Use this option if your image is pixel art"
         />
@@ -268,6 +288,48 @@
     {#if $data.impactSoundIds.length > 0}
       <SelectedSounds soundIds={$data.impactSoundIds} />
       <FormErrorLabel name="impactSoundIds" />
+    {/if}
+  </FormSection>
+{/snippet}
+
+{#snippet windupTab()}
+  <FormSection
+    title="Windup"
+    description="Add a windup delay and sound before the item is thrown"
+    empty={!$data.config.windup.enabled}
+  >
+    {#snippet action()}
+      <EnabledSwitch
+        checked={$data.config.windup.enabled}
+        onCheckedChange={(value) =>
+          setFields("config.windup.enabled", value, true)}
+      />
+    {/snippet}
+
+    <FormNumberInput
+      id="config.windup.duration"
+      name="config.windup.duration"
+      label="Duration"
+      description="How long the windup should take (ms)"
+      min={0}
+      step={100}
+    />
+
+    <SoundPicker
+      description="Choose which sounds can play for the windup (Randomly chosen from the selection)"
+      selected={$data.windupSoundIds}
+      onChangeSelected={(soundIds) => {
+        setFields(
+          "windupSoundIds",
+          soundIds.map((sound) => sound.id),
+          true,
+        );
+      }}
+    />
+
+    {#if $data.windupSoundIds.length > 0}
+      <SelectedSounds soundIds={$data.windupSoundIds} />
+      <FormErrorLabel name="windupSoundIds" />
     {/if}
   </FormSection>
 {/snippet}
@@ -333,6 +395,12 @@
           icon: SolarHeadphonesRoundBoldDuotone,
           label: "Sounds",
           content: soundsTab,
+        },
+        {
+          value: "windup",
+          icon: SolarMultipleForwardRightBoldDuotone,
+          label: "Windup",
+          content: windupTab,
         },
       ]}
     />

--- a/src/lib/sections/throwables/ThrowableItem.svelte
+++ b/src/lib/sections/throwables/ThrowableItem.svelte
@@ -65,8 +65,8 @@
     <div class="item__image-wrapper">
       <img
         class="item__image"
-        class:item__image--pixelate={config.image.pixelate}
-        src={getBackendURL(config.image.src)}
+        class:item__image--pixelate={config.config.image.pixelate}
+        src={getBackendURL(config.config.image.src)}
         alt="Throwable"
         loading="lazy"
       />

--- a/types/dataV2.ts
+++ b/types/dataV2.ts
@@ -2,18 +2,28 @@ import type { Uuid } from "./appData";
 
 export type ItemId = Uuid;
 
-export type ThrowableImageConfig = {
+export type ItemImageConfig = {
   src: string;
   weight: number;
   scale: number;
   pixelate: boolean;
 };
 
+export type ItemWindupConfig = {
+  enabled: boolean;
+  duration: number;
+};
+
 export type Item = {
   id: ItemId;
   name: string;
-  image: ThrowableImageConfig;
+  config: ItemConfig;
   order: number;
+};
+
+export type ItemConfig = {
+  image: ItemImageConfig;
+  windup: ItemWindupConfig;
 };
 
 export type SoundId = Uuid;


### PR DESCRIPTION
## Description

Changes item sound relations to include a sound type, massive refactoring of internal data formats which will require some documentation updates. Addition of windup sounds

## Changes
- Sounds can be for different types of things now (Impact, Windup, etc)
- Items now have a config object instead of an image object in the db for storing the windup config and future configs like impact decal
- Sound loading is more efficient (Was loading more than needed before)
- Fixed tab styling and spacing for sound selection 
- Windup sounds
